### PR TITLE
remove linter comment

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import Image from 'next/image'
 import styles from './page.module.css'
 


### PR DESCRIPTION
Got `next/images` to work by hard coding the whole url.  This linter comment is no longer needed.